### PR TITLE
refactor registration page and add react hook form

### DIFF
--- a/app/(tabs)/registration.tsx
+++ b/app/(tabs)/registration.tsx
@@ -1,54 +1,167 @@
 import React from 'react';
 import { View, Text } from '../../components/Themed';
 import { TextInput, Pressable } from 'react-native';
-import { Link } from 'expo-router';
+import { Link, useRouter } from 'expo-router';
+import { useForm, Controller } from 'react-hook-form';
 
 export default function Registration() {
+  const { control, handleSubmit, watch } = useForm();
+  const emailRegex = /^[\w\.-]+@[a-zA-Z\d\.-]+\.[a-zA-Z]{2,}$/
+  const passwordValidation = watch('password')
+
+  const router = useRouter();
+
+  const registerPress = (data: any) => {
+    router.push('/home')
+    console.log(data)
+  }
+
   return (
     <>
-    <View className="flex-1 self-stretch justify-center bg-white dark:bg-black">
-      <Text className='ml-7 mb-5 text-3xl'>
+    <View className="flex-1 self-stretch items-center justify-center bg-white dark:bg-black">
+      <Text className=' text-5xl'>
         Sign Up
       </Text>
-      <View className='items-center'>
-        <TextInput
-          className='pl-2 rounded-lg bg-slate-300 w-10/12 m-3 border border-black dark:border-white h-10 justify-center'
-          placeholder='First Name'
-          placeholderTextColor='black'
-        /> 
 
-        <TextInput
-          className='pl-2 rounded-lg bg-slate-300 w-10/12 m-3 border border-black dark:border-white h-10 justify-center'
-          placeholder='Last Name'
-          placeholderTextColor='black'
-        /> 
+      <Controller
+        control={control}
+        name="firstName"
+        rules={{required: 'Please enter your First Name'}}
+        render={({field: {value, onBlur, onChange}, fieldState: {error}}) => (
+          <>
+          <TextInput
+            style= {[{borderColor: error ? 'red' : 'gray'}]}
+            className= 'w-2/3 h-10 rounded-xl border bg-slate-50 border-radius-20 mb-2 px-5 mt-9'
+            placeholder='First Name'
+            placeholderTextColor='black'
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+          />
+          { error && (
+            <Text className='w-7/12 text-red-600'>{error.message || 'Error'}</Text>
+          )}
+          </>
+        )}
+      />
 
-        <TextInput
-          className='pl-2 rounded-lg bg-slate-300 w-10/12 m-3 border border-black dark:border-white h-10 justify-center'
-          placeholder='Email'
-          placeholderTextColor='black'
-        /> 
+      <Controller
+        control={control}
+        name="lastName"
+        rules={{required: 'Please enter your Last Name'}}
+        render={({field: {value, onBlur, onChange}, fieldState: {error}}) => (
+          <>
+          <TextInput
+            style= {[{borderColor: error ? 'red' : 'gray'}]}
+            className='w-2/3 h-10 rounded-xl border bg-slate-50 border-radius-20 mb-2 px-5 mt-2'
+            placeholder='Last Name'
+            placeholderTextColor='black'
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+          /> 
+          { error && (
+            <Text className='w-7/12 text-red-600'>{error.message || 'Error'}</Text>
+          )}
+          </>
+        )}
+      />
 
-        <TextInput
-          className='pl-2 rounded-lg bg-slate-300 w-10/12 m-3 border border-black dark:border-white h-10 justify-center'
-          placeholder='Password'
-          placeholderTextColor='black'
-          secureTextEntry={true}
-        /> 
+      <Controller
+        control={control}
+        name="email"
+        rules={{
+          required: 'Email address required',
+          pattern: {value: emailRegex, message: 'Enter a valid email address'}
+        }}
+        render={({field: {value, onBlur, onChange}, fieldState: {error}}) => (
+          <>
+          <TextInput
+            style= {[{borderColor: error ? 'red' : 'gray'}]}
+            className='w-2/3 h-10 rounded-xl border bg-slate-50 border-radius-20 mb-2 px-5 mt-2'
+            placeholder='Email'
+            placeholderTextColor='black'
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+          /> 
+          { error && (
+            <Text className='w-7/12 text-red-600'>{error.message || 'Error'}</Text>
+          )}
+          </>
+        )}
+      />
 
-        <TextInput
-          className='pl-2 rounded-lg bg-slate-300 w-10/12 m-3 border border-black dark:border-white h-10 justify-center'
-          placeholder='Re-enter Password'
-          placeholderTextColor='black'
-          secureTextEntry={true}
-        /> 
+      <Controller
+        control={control}
+        name="password"
+        rules={{
+          required: 'Password is required',
+          minLength: {value: 6, message: 'Password must be at least 6 characters'}
+        }}
+        render={({field: {value, onBlur, onChange}, fieldState: {error}}) => (
+          <>
+          <TextInput
+            style= {[{borderColor: error ? 'red' : 'gray'}]}
+            className='w-2/3 h-10 rounded-xl border bg-slate-50 border-radius-20 mb-2 px-5 mt-2'
+            placeholder='Password'
+            placeholderTextColor='black'
+            secureTextEntry={true}
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+          /> 
+          { error && (
+            <Text className='w-7/12 text-red-600'>{error.message || 'Error'}</Text>
+          )}          
+          </>
+        )}
+      />
 
-        <Link href={'/homescreen'} asChild>
-          <Pressable className='mt-7 w-4/12 h-9 items-center justify-center bg-green-800 rounded-lg'>
-            <Text className='text-white text-base'>Sign Up</Text>
-          </Pressable>
-        </Link>
+      <Controller
+        control={control}
+        name="password-repeat"
+        rules={{
+          required: 'Re-enter your password',
+          validate: value =>
+            value === passwordValidation || 'Passwords do not match'
+        }}
+        render={({field: {value, onBlur, onChange}, fieldState: {error}}) => (
+          <>
+          <TextInput
+            style= {[{borderColor: error ? 'red' : 'gray'}]}
+            className='w-2/3 h-10 rounded-xl border bg-slate-50 border-radius-20 mb-2 px-5 mt-2'
+            placeholder='Re-enter Password'
+            placeholderTextColor='black'
+            secureTextEntry={true}
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+          />
+          { error && (
+            <Text className='w-7/12 text-red-600'>{error.message || 'Error'}</Text>
+          )}          
+          </>
+        )}
+      />
+
+      <Pressable
+        className='w-1/3 bg-green-800 font-bold rounded-md py-2 px-4 mb-5 mt-8'
+        onPress={handleSubmit(registerPress)}
+      >
+        <Text className='text-white text-center'>Sign Up</Text>
+      </Pressable>
+
+      
+      <View className="flex-row items-center mb-2">
+        <Text className=" mt-5">Already have an account?</Text>
       </View>
+      
+      <Link href={'/login'} asChild>
+        <Pressable className="ml-2">
+          <Text className="text-green-700">Login here</Text>
+        </Pressable>
+      </Link>
     </View>
     </>
   )

--- a/app/(tabs)/registration.tsx
+++ b/app/(tabs)/registration.tsx
@@ -97,7 +97,7 @@ export default function Registration() {
         name="password"
         rules={{
           required: 'Password is required',
-          minLength: {value: 6, message: 'Password must be at least 6 characters'}
+          minLength: {value: 8, message: 'Password must be at least 8 characters'}
         }}
         render={({field: {value, onBlur, onChange}, fieldState: {error}}) => (
           <>
@@ -122,7 +122,7 @@ export default function Registration() {
         control={control}
         name="password-repeat"
         rules={{
-          required: 'Re-enter your password',
+          required: 'Confirm your password',
           validate: value =>
             value === passwordValidation || 'Passwords do not match'
         }}
@@ -131,7 +131,7 @@ export default function Registration() {
           <TextInput
             style= {[{borderColor: error ? 'red' : 'gray'}]}
             className='w-2/3 h-10 rounded-xl border bg-slate-50 border-radius-20 mb-2 px-5 mt-2'
-            placeholder='Re-enter Password'
+            placeholder='Confirm Password'
             placeholderTextColor='black'
             secureTextEntry={true}
             value={value}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "nativewind": "^2.0.11",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-hook-form": "^7.45.2",
         "react-native": "0.71.8",
         "react-native-dotenv": "^3.4.9",
         "react-native-safe-area-context": "4.5.0",
@@ -17350,6 +17351,21 @@
       "peerDependencies": {
         "react": "^16.6.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.45.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.45.2.tgz",
+      "integrity": "sha512-9s45OdTaKN+4NSTbXVqeDITd/nwIg++nxJGL8+OD5uf1DxvhsXQ641kaYHk5K28cpIOTYm71O/fYk7rFaygb3A==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "nativewind": "^2.0.11",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.45.2",
     "react-native": "0.71.8",
     "react-native-dotenv": "^3.4.9",
     "react-native-safe-area-context": "4.5.0",


### PR DESCRIPTION
[refactor] refectored the registration page by wrapping it in react hook form.

This allows the user to register using their email and password.
**Also included requirements for each form:**
- All the fields are required (first name, last name, email, password, etc.)
- included email regex to verify if the email submitted is valid
- minimum of 6 characters needed for the password
- password and re-enter password must be equal

**IF THE REQUIREMENTS ARE NOT MET, IT SHOWS AN ERROR MESSAGE:**
![Screenshot_20230725_204343_Expo_Go](https://github.com/splitscale/arrow/assets/124236637/69820f1e-c489-4570-bbe7-9b3cee9c879f)

**IF THE REQUIREMENTS ARE MET, THEN IT SUBMITS THE FORM AND SENDS THE USER TO HOME SCREEN:**
![358697774_1288363895114799_1002729716444667948_n](https://github.com/splitscale/arrow/assets/124236637/0626a099-e620-4f14-8a94-789039ee4c21)

![Screenshot 2023-07-27 180226](https://github.com/splitscale/arrow/assets/124236637/d778caf5-2fe4-4fe3-98b9-31b1e0be7a9a)
