### PR TITLE
[feature] Add readAllListingsInfoHandler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arrow",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "scripts": {
     "start": "expo start --dev-client",
     "android": "expo run:android",

--- a/service/__tests__/integration/listingInfo.test.ts
+++ b/service/__tests__/integration/listingInfo.test.ts
@@ -54,6 +54,23 @@ describe('Listing info integration test', () => {
     }
   });
 
+  it('should be able to return all listing info', async() => {
+    const request: DuffleRequest = {
+      method: 'GET',
+      url: '/api/listinginfo'
+    };
+
+    try {
+      const res = await service.resolve(request);
+      console.log(res);
+      return Promise.resolve();
+    } catch (error) {
+      console.error(error);
+      return Promise.reject();
+    }
+
+  });
+
   afterAll(async () => {
     await Promise.all([deleteApp(FirebaseConfigurer.getFirebaseApp())]);
   });

--- a/service/core-services/listingInfoManagement/handlers/readAllListingsInfoHandler.ts
+++ b/service/core-services/listingInfoManagement/handlers/readAllListingsInfoHandler.ts
@@ -1,0 +1,42 @@
+import { BaseHandler, DuffleRequest, DuffleResponse } from 'duffle';
+import BaseRepository from '../../../repository/baseRepository';
+import { ListingRepositoryInteractor } from '../listingRepositoryInteractor';
+
+export class ReadAllListingsInfoHandler extends BaseHandler {
+
+    private readonly interactor: ListingRepositoryInteractor;
+
+    constructor(db: BaseRepository){
+        super();
+
+        this.method = 'GET';
+        this.endpoint = '/api/listinginfo';
+        this.interactor =  new ListingRepositoryInteractor(db);
+        
+    }
+
+    public async handle(request: DuffleRequest): Promise<DuffleResponse> {
+        try {
+          const data = await this.interactor.getAll();
+    
+          if (!data) {
+            throw new Error(`No listings`);
+          }
+    
+          const res: DuffleResponse = {
+            status: 'OK',
+            body: data,
+          };
+    
+          return Promise.resolve(res);
+        } catch (error) {
+          const res: DuffleResponse = {
+            status: 'ERROR',
+            body: error as string,
+          };
+    
+          return Promise.reject(res);
+        }
+      }
+    
+}

--- a/service/core-services/listingInfoManagement/listingRegistrator.ts
+++ b/service/core-services/listingInfoManagement/listingRegistrator.ts
@@ -2,11 +2,13 @@ import { BaseHandlerRegistrator } from 'duffle/bin/baseHandlerRegistrator';
 import BaseRepository from '../../repository/baseRepository';
 import { AddListingInfoHandler } from './handlers/addListingInfoHandler';
 import { ReadOneListingInfoHandler } from './handlers/readOneListingInfoHandler';
+import { ReadAllListingsInfoHandler } from './handlers/readAllListingsInfoHandler';
 
 export class ListingRegistrator extends BaseHandlerRegistrator {
   constructor(db: BaseRepository) {
     super();
     this.handlers.push(new AddListingInfoHandler(db));
     this.handlers.push(new ReadOneListingInfoHandler(db));
+    this.handlers.push(new ReadAllListingsInfoHandler(db));
   }
 }


### PR DESCRIPTION
This PR adds a new handler for viewing listing information. It returns all the listings in the repository.

Overview / Description

## Changes
- added readAllListingsInfoHandler.ts
- modified listingInfo.test.ts to add a test for the new handler
- modified listingRegistrator.ts to push the new handler to the registrator

## Screenshots
(prefer animated gif)

## Checklist
- [x] Automated tests
- [ ] Checked on iOS
- [ ] Checked on Android

Fixes #xx
