### PR TITLE
[bugfix] map to object not working properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "updateSnapshots": "jest -u --coverage=false",
     "prebuild": "npx expo prebuild && npx react-native run-android",
     "dev": "npx react-native run-android",
-    "deploy": "npx expo prebuild && eas build --platform android"
+    "deploy": "npx expo prebuild && eas build --platform android",
+    "testCurrentFile": "jest --watch"
   },
   "dependencies": {
     "@expo/vector-icons": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arrow",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "scripts": {
     "start": "expo start --dev-client",
     "android": "expo run:android",

--- a/service/__tests__/integration/listingInfo.test.ts
+++ b/service/__tests__/integration/listingInfo.test.ts
@@ -5,18 +5,22 @@ import FirebaseConfigurer from '../../dataAccess/firebase/firebaseConfigurer';
 
 describe('Listing info integration test', () => {
   it('should be able to add a new property listing to the database', async () => {
+    const data = {
+      userId: 'test-userId',
+      images: 'test-images',
+      coordinates: { lat: 72, long: 144 },
+      propertyName: 'test-propertyName',
+      bedType: 'test-bedType',
+      description: 'test-description',
+      amenities: 'test-amenities',
+      prices: 'test-prices',
+      availabilityStatus: 'test-availabilityStatus',
+      houseRules: 'test-houseRules',
+    };
+
     const body = new Map<string, any>();
-    body.set('userId', 'test-userId');
-    body.set('images', 'test-images');
-    body.set('coordinates', { lat: 72, long: 144 });
-    body.set('propertyName', 'test-propertyName');
-    body.set('bedType', 'test-bedType');
-    body.set('description', 'test-description');
-    body.set('amenities', 'test-amenities');
-    body.set('prices', 'test-prices');
-    body.set('availabilityStatus', 'test-availabilityStatus');
-    body.set('houseRules', 'test-houseRules');
     body.set('id', 'test-id');
+    body.set('data', data);
 
     const request: DuffleRequest = {
       method: 'POST',
@@ -54,10 +58,10 @@ describe('Listing info integration test', () => {
     }
   });
 
-  it('should be able to return all listing info', async() => {
+  it('should be able to return all listing info', async () => {
     const request: DuffleRequest = {
       method: 'GET',
-      url: '/api/listinginfo'
+      url: '/api/listinginfo',
     };
 
     try {
@@ -68,7 +72,6 @@ describe('Listing info integration test', () => {
       console.error(error);
       return Promise.reject();
     }
-
   });
 
   afterAll(async () => {

--- a/service/__tests__/integration/userInfo.test.ts
+++ b/service/__tests__/integration/userInfo.test.ts
@@ -1,18 +1,22 @@
-import { DuffleRequest } from "duffle";
-import { service } from "../..";
-import { deleteApp } from "firebase/app";
-import FirebaseConfigurer from "../../dataAccess/firebase/firebaseConfigurer";
+import { DuffleRequest } from 'duffle';
+import { service } from '../..';
+import { deleteApp } from 'firebase/app';
+import FirebaseConfigurer from '../../dataAccess/firebase/firebaseConfigurer';
 
 describe('user info integration test', () => {
   it('should be able to add a new userInfo to the database', async () => {
+    const data = {
+      firstName: 'john',
+      lastName: 'wick',
+      userName: 'johnwick',
+      email: 'wick@john.com',
+      photoUrl: 'wick-pic',
+      phoneNumber: '0912345689',
+    };
+
     const body = new Map<string, any>();
-    body.set('firstName', 'john');
-    body.set('lastName', 'wick');
-    body.set('userName', 'johnwick');
-    body.set('email', 'wick@john.com');
-    body.set('photoUrl', 'wick-pic');
-    body.set('phoneNumber', '0912345689');
     body.set('id', 'test-id');
+    body.set('data', data);
 
     const request: DuffleRequest = {
       method: 'POST',
@@ -32,9 +36,9 @@ describe('user info integration test', () => {
 
   it('should be able to read all userInfo', async () => {
     const req: DuffleRequest = {
-      method: "GET",
-      url: "/api/userinfo",
-    }
+      method: 'GET',
+      url: '/api/userinfo',
+    };
 
     try {
       const res = await service.resolve(req);
@@ -44,17 +48,17 @@ describe('user info integration test', () => {
       console.error(error);
       Promise.reject();
     }
-  })
+  });
 
   it('should be able to read one of the userInfo', async () => {
     const body = new Map<string, any>();
     body.set('id', 'test-id');
 
     const req: DuffleRequest = {
-      method: "GET",
-      url: "/api/userinfo/id",
-      body: body
-    }
+      method: 'GET',
+      url: '/api/userinfo/id',
+      body: body,
+    };
 
     try {
       const res = await service.resolve(req);
@@ -64,7 +68,7 @@ describe('user info integration test', () => {
       console.error(error);
       Promise.reject();
     }
-  })
+  });
 
   it('should be able to update userInfo', async () => {
     try {
@@ -78,10 +82,10 @@ describe('user info integration test', () => {
       bodyCopy.set('id', 'test-id');
 
       const req: DuffleRequest = {
-        method: "PUT",
-        url: "/api/userinfo",
+        method: 'PUT',
+        url: '/api/userinfo',
         body: bodyCopy,
-      }
+      };
       const res = await service.resolve(req);
       console.log(res.body);
       Promise.resolve();
@@ -89,17 +93,17 @@ describe('user info integration test', () => {
       console.error(error);
       Promise.reject();
     }
-  })
+  });
 
   it('should be able to delete userInfo', async () => {
-    const body = new Map<string,any> ()
-    body.set('id','test-id');
+    const body = new Map<string, any>();
+    body.set('id', 'test-id');
 
     const req: DuffleRequest = {
-      method: "DELETE",
-      url: "/api/userinfo",
-      body: body
-    }
+      method: 'DELETE',
+      url: '/api/userinfo',
+      body: body,
+    };
 
     try {
       const res = await service.resolve(req);
@@ -109,9 +113,9 @@ describe('user info integration test', () => {
       console.error(error);
       Promise.reject();
     }
-  })
+  });
 
   afterAll(async () => {
     await Promise.all([deleteApp(FirebaseConfigurer.getFirebaseApp())]);
   });
-})
+});

--- a/service/core-services/listingInfoManagement/handlers/addListingInfoHandler.ts
+++ b/service/core-services/listingInfoManagement/handlers/addListingInfoHandler.ts
@@ -1,6 +1,10 @@
 import { BaseHandler, DuffleRequest, DuffleResponse } from 'duffle';
 import BaseRepository from '../../../repository/baseRepository';
 import { ListingRepositoryInteractor } from '../listingRepositoryInteractor';
+import { UserInfo } from 'firebase/auth';
+import { convertMapToObject } from '../../../../utils/convertMapToObject';
+import { ObjectWithIdWrapperWithMetadata } from '../../../repository/repositoryTypes';
+import { ListingInfo } from '../type/listingInfoType';
 
 export class AddListingInfoHandler extends BaseHandler {
   private readonly interactor: ListingRepositoryInteractor;
@@ -16,41 +20,27 @@ export class AddListingInfoHandler extends BaseHandler {
   public async handle(request: DuffleRequest): Promise<DuffleResponse> {
     const body = request.body as Map<string, any> | undefined;
 
-    const userId = body?.get('userId');
-    const images = body?.get('images');
-    const coordinates = body?.get('coordinates');
-    const propertyName = body?.get('propertyName');
-    const bedType = body?.get('bedType');
-    const description = body?.get('description');
-    const amenities = body?.get('amenities');
-    const prices = body?.get('prices');
-    const availabilityStatus = body?.get('availabilityStatus');
-    const houseRules = body?.get('houseRules');
+    if (!body) {
+      throw new Error('cannot add user info, request body is undefined');
+    }
 
-    const docId = body?.get('id');
-    const metadata = body?.get('metadata');
+    const { id, data, metadata } =
+      convertMapToObject<
+        ObjectWithIdWrapperWithMetadata<ListingInfo, string, any>
+      >(body);
+
+    console.log([id, data, metadata]);
 
     try {
-      const id = await this.interactor.add({
-        id: docId,
-        data: {
-          userId: userId,
-          images: images,
-          coordinates: coordinates,
-          propertyName: propertyName,
-          bedType: bedType,
-          description: description,
-          amenities: amenities,
-          prices: prices,
-          availabilityStatus: availabilityStatus,
-          houseRules: houseRules
-        },
+      const resId = await this.interactor.add({
+        id: id,
+        data: data,
         metadata: metadata,
       });
 
       const res: DuffleResponse = {
         status: 'OK',
-        body: id,
+        body: resId,
       };
 
       return Promise.resolve(res);

--- a/service/core-services/userInfoManagementService/handlers/addUserInfoHandler.ts
+++ b/service/core-services/userInfoManagementService/handlers/addUserInfoHandler.ts
@@ -23,32 +23,18 @@ export class AddUserInfoHandler extends BaseHandler {
       throw new Error('cannot add user info, request body is undefined');
     }
 
-    const {
-      firstName,
-      lastName,
-      userName,
-      email,
-      photoUrl,
-      phoneNumber,
-      id,
-      metadata,
-    } =
+    const { id, data, metadata } =
       convertMapToObject<
         ObjectWithIdWrapperWithMetadata<UserInfo, string, any>
       >(body);
 
+    console.log([id, data, metadata]);
+
     try {
       const resId = await this.interactor.add({
         id: id,
-        data: {
-          firstName: firstName,
-          lastName: lastName,
-          userName: userName ?? null,
-          email: email,
-          photoUrl: photoUrl ?? null,
-          phoneNumber: phoneNumber ?? null,
-        },
-        metadata: metadata ?? null,
+        data: data,
+        metadata: metadata,
       });
 
       if (!id) {

--- a/service/repository/repositoryTypes.ts
+++ b/service/repository/repositoryTypes.ts
@@ -12,12 +12,13 @@ export interface RepositoryDocumentRequestOf<T> {
 
 export type ObjectWithIdWrapper<T, ID extends string | number> = {
   id: ID;
-} & T;
+  data: T;
+};
 
 export type ObjectWithIdWrapperWithMetadata<
-  T,
+  Body,
   ID extends string | number,
   Meta = null
-> = ObjectWithIdWrapper<T, ID> & {
+> = ObjectWithIdWrapper<Body, ID> & {
   metadata: Meta; // Setting the default value of metadata to null
 };

--- a/utils/__tests__/mapToObjConvert.test.ts
+++ b/utils/__tests__/mapToObjConvert.test.ts
@@ -1,3 +1,4 @@
+import { ObjectWithIdWrapperWithMetadata } from '../../service/repository/repositoryTypes';
 import { convertMapToObject } from '../convertMapToObject';
 
 describe('mapToObject', () => {
@@ -18,6 +19,40 @@ describe('mapToObject', () => {
       age: number;
       location: string;
     }>(myMap);
+
+    console.log([expectedResult, result]);
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('should convert a map to an object with type wrapper', () => {
+    interface TestUser {
+      name: string;
+      age: number;
+      location: string;
+    }
+
+    const myMap = new Map<string, any>();
+    myMap.set('id', 'some-id');
+    myMap.set('data', { name: 'John', age: 30, location: 'Iloilo' });
+    myMap.set('metadata', 'some-metadata');
+
+    const expectedResult: ObjectWithIdWrapperWithMetadata<
+      TestUser,
+      string,
+      any
+    > = {
+      id: 'some-id',
+      data: { name: 'John', age: 30, location: 'Iloilo' },
+      metadata: 'some-metadata',
+    };
+
+    const result =
+      convertMapToObject<
+        ObjectWithIdWrapperWithMetadata<TestUser, string, any>
+      >(myMap);
+
+    console.log([expectedResult, result]);
 
     expect(result).toEqual(expectedResult);
   });

--- a/utils/convertMapToObject.ts
+++ b/utils/convertMapToObject.ts
@@ -2,7 +2,7 @@ export function convertMapToObject<T>(map: Map<string, any>): T {
   const obj: any = {};
 
   for (const [key, value] of map.entries()) {
-    obj[key] = value;
+    obj[key] = value ?? null;
   }
 
   return obj as T;

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,9 +1,17 @@
 import { saveLogsToDb } from './saveLogsToDb';
 
 class Logger {
+  private logs: any[] = [];
+
   private saveLog(msg: any) {
-    saveLogsToDb(msg)
-      .then(() => {})
+    this.logs.push(msg);
+  }
+
+  public saveLogs() {
+    Promise.all(this.logs.map((log) => saveLogsToDb(log)))
+      .then(() => {
+        this.logs = [];
+      }) // Clear logs after saving
       .catch(console.error);
   }
 


### PR DESCRIPTION
should be able to process this
type of duffle request body:

```typescript
const body = new Map<string, any>();

myMap.set('id', 'some-id');
myMap.set('data', { name: 'John', age: 30, location: 'Iloilo' }); // put any object here
myMap.set('metadata', 'some-metadata'); // put any object here
```